### PR TITLE
update test to accept any path for contract

### DIFF
--- a/packages/foundry/test/WrappedETH.t.sol
+++ b/packages/foundry/test/WrappedETH.t.sol
@@ -12,6 +12,12 @@ contract WrappedETHTest is Test {
 
     function setUp() public {
         wrappedETH = new WrappedETH();
+        // Use a different contract than default if CONTRACT_PATH env var is set
+        string memory contractPath = vm.envOr("CONTRACT_PATH", string("none"));
+        if (keccak256(abi.encodePacked(contractPath)) != keccak256(abi.encodePacked("none"))) {
+            bytes memory contractCode = vm.getDeployedCode(contractPath);
+            vm.etch(address(wrappedETH), contractCode);
+        }
     }
 
     function testDeposit() public {


### PR DESCRIPTION
This makes it possible to change the contract used in the test by providing a CONTRACT_PATH environment variable. This is necessary for the backend to efficiently test user contracts.